### PR TITLE
Require Python 3.10 or higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 description = "automated pipeline interfacing with render-ws rest api"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
Because Python 3.9 does not support match - case