### PR TITLE
Post correction global

### DIFF
--- a/scripted_render_pipeline/postcorrector/__main__.py
+++ b/scripted_render_pipeline/postcorrector/__main__.py
@@ -4,27 +4,27 @@ relies on provided parameters being set in the script for now
 """
 import logging
 import pathlib
-
+from natsort import natsorted
 from .post_corrector import Post_Corrector
 
 # script properties
-PROJECT = "20230914_RP_exocrine_partial_test"
+PROJECT = "20231212_MC7_NdAc"
 PARALLEL = 40  # read this many images in parallel to optimise io usage
-CLOBBER = False  # set to false to fail if data would be overwritten
+CLOBBER = True  # set to false to fail if data would be overwritten
 REMOTE = False  # set to false if ran locally
 NAS_SHARE_PATH = pathlib.Path.home() / "shares/long_term_storage"
 SERVER_STORAGE_PATH_STR = "/long_term_storage/"
 PROJECT_PATH = (
     NAS_SHARE_PATH if REMOTE else pathlib.Path(SERVER_STORAGE_PATH_STR)
-) / f"akievits/FAST-EM/{PROJECT}"
+) / f"akievits/FAST-EM/tests/{PROJECT}"
 MULTIPLE_SECTIONS = True  # Set to False for a single section
 
 # Processing parameters
 PCT = 0.1
-A = 1
+A = 3
 
 if MULTIPLE_SECTIONS:
-    PROJECT_PATHS = [p for p in PROJECT_PATH.iterdir() if p.is_dir()]
+    PROJECT_PATHS = natsorted([p for p in PROJECT_PATH.iterdir() if (p.is_dir() and not p.name.startswith('_'))])
 else:
     PROJECT_PATHS = None
 
@@ -39,8 +39,14 @@ def _main():
         project_paths=PROJECT_PATHS,
     )
 
-    post_corrector.post_correct_all_sections()
-    logging.info("post-correction completed")
+    failed_sections = post_corrector.post_correct_all_sections()
+    if not failed_sections:
+        logging.info("post-correction completed succesfully")
+    else:
+        logging.info("Post_correction failed for: %s", [section.name for section in failed_sections])      
+        logging.info("Detected failed sections. Rerunning post-correction using nearest available correction image")
+        post_corrector.post_correct_failed_sections(failed_sections)
+
 
 
 if __name__ == "__main__":

--- a/scripted_render_pipeline/postcorrector/__main__.py
+++ b/scripted_render_pipeline/postcorrector/__main__.py
@@ -16,12 +16,12 @@ NAS_SHARE_PATH = pathlib.Path.home() / "shares/long_term_storage"
 SERVER_STORAGE_PATH_STR = "/long_term_storage/"
 PROJECT_PATH = (
     NAS_SHARE_PATH if REMOTE else pathlib.Path(SERVER_STORAGE_PATH_STR)
-) / f"akievits/FAST-EM/tests/{PROJECT}"
+) / f"akievits/FAST-EM/{PROJECT}"
 MULTIPLE_SECTIONS = True  # Set to False for a single section
 
 # Processing parameters
 PCT = 0.1
-A = 3
+A = 1
 
 if MULTIPLE_SECTIONS:
     PROJECT_PATHS = natsorted([p for p in PROJECT_PATH.iterdir() if (p.is_dir() and not p.name.startswith('_'))])

--- a/scripted_render_pipeline/postcorrector/post_corrector.py
+++ b/scripted_render_pipeline/postcorrector/post_corrector.py
@@ -23,6 +23,7 @@ TIFFILE_GLOB = (
 )
 RESTORE_MEAN_LEVEL = 32768
 SAMPLE_SIZE = 10
+MIN_CLEAN = 20
 
 
 class Post_Corrector:
@@ -150,7 +151,7 @@ class Post_Corrector:
                     fps_clean.append(file_path)
         # Create post-corrected images based on non-corrupted images 
         # only if sufficient number of clean images is available
-        if len(fps_clean) > 10:
+        if len(fps_clean) > MIN_CLEAN:
             self.post_correct(filepaths, fps_clean)
             return []
         else:


### PR DESCRIPTION
Post-correction has been updated to perform a global correction, by sampling N images per section and then compute global MED and MAD values, instead of calculating these values for each section separately. This handles problematic sections with a lot of artifacts more effectively. A correction image is produced if the number of artefact-free images in a section is higher than a set value, defaulting to 20. The actual correction is still performed on a per-section basis, although if a correction image is not available, the image from the nearest section in z is used instead. 

For detailed explanation, see this issue: https://github.com/hoogenboom-group/interactive-render-workflow/issues/13