### PR TITLE
read the capture time from the IJMetadata tag

### DIFF
--- a/scripted_render_pipeline/importer/mipmapper.py
+++ b/scripted_render_pipeline/importer/mipmapper.py
@@ -111,6 +111,12 @@ class Mipmapper(abc.ABC):
                 future = executor.submit(self.create_mipmaps, args)
                 futures.add(future)
 
+            if not futures:
+                logging.warning(
+                    "found no files, check if project paths are correct"
+                )
+                return []
+
             for future in tqdm(
                 concurrent.futures.as_completed(futures),
                 desc="making mipmaps",


### PR DESCRIPTION
changes to the fastem correction software now add a new tag IJMetadata (presumably ImageJ metadata) that contains a date field, this field can be used instead of the missing DateTime tag in corrected images.

I am not sure if this date field is the same as the original DateTime tag from the pre-corrected images but it seems to be.