### PR TITLE
improve clem mipmapper

### DIFF
--- a/scripted_render_pipeline/importer/__main__.py
+++ b/scripted_render_pipeline/importer/__main__.py
@@ -31,6 +31,8 @@ PROJECT_PATH = (
     / f"akievits/FAST-EM/tests/{PROJECT}" # Path to data
 )
 MIPMAP_TYPE = "FASTEM"  # "CLEM"
+# for fastem datasets only
+USE_POSITIONS = False  # use the automated stitching results
 
 # for FAST-EM datasets only
 USE_POSITIONS = True  # use the automated stitching results from acquisition software
@@ -58,6 +60,7 @@ def _main():
     if not stacks:
         raise RuntimeError("no stacks to upload")
 
+    breakpoint()
     uploader = Uploader(HOST, OWNER, PROJECT, auth, CLOBBER)
     uploader.upload_to_render(stacks, Z_RESOLUTION)
     logging.info("import completed")

--- a/scripted_render_pipeline/importer/__main__.py
+++ b/scripted_render_pipeline/importer/__main__.py
@@ -4,6 +4,7 @@ Makes MIPmaps
 
 relies on provided parameters being set in the script for now
 """
+
 import logging
 import pathlib
 from natsort import natsorted
@@ -14,41 +15,65 @@ from .fastem_mipmapper import FASTEM_Mipmapper
 from .uploader import Uploader
 
 # render properties
-HOST = "https://sonic.tnw.tudelft.nl" # Web address which hosts render-ws. It's usually the preamble of the link to render-ws html page, i.e. {host_name}/render-ws/view/index.html
-OWNER = "akievits" # render-ws ID of dataset
-PROJECT = "20231107_MCF7_UAC_test" # Project directory on disk
-CORRECTIONS_DIR = "postcorrection" # name of postcorrection directory
+HOST = "https://sonic.tnw.tudelft.nl"
+OWNER = "thopp"
+PROJECT = "SK0002_H004_A001_subdataset"
 
 # script properties
+MIPMAP_TYPE = "CLEM"  # which mipmapper to use, either FASTEM or CLEM
 PARALLEL = 40  # read this many images in parallel to optimise io usage
 CLOBBER = True  # set to false to fail if data would be overwritten
 Z_RESOLUTION = 100  # the thickness of sections
-REMOTE = False  # set to false if ran locally
+REMOTE = True  # set to false if ran locally
+# the location the nas is mounted on this machine, only used when remote
 NAS_SHARE_PATH = pathlib.Path.home() / "shares/long_term_storage"
-SERVER_STORAGE_PATH_STR = "/long_term_storage/" # Base storage path
-PROJECT_PATH = (
-    (NAS_SHARE_PATH if REMOTE else pathlib.Path(SERVER_STORAGE_PATH_STR))
-    / f"akievits/FAST-EM/tests/{PROJECT}" # Path to data
-)
-MIPMAP_TYPE = "FASTEM"  # "CLEM"
-# for fastem datasets only
-USE_POSITIONS = False  # use the automated stitching results
+SERVER_STORAGE_PATH_STR = "/long_term_storage/"  # Base storage path
+# Path to data
+PROJECT_PATH_STR = "skaracoban/test_data/SK0002_H004_A001_subdataset"
+MIPMAP_PATH_STR = "thopp/SK0002_H004_A001_subdataset_mipmaps"
+if REMOTE:
+    PROJECT_PATH = NAS_SHARE_PATH / PROJECT_PATH_STR
+    MIPMAP_PATH = NAS_SHARE_PATH / MIPMAP_PATH_STR
+else:
+    PROJECT_PATH = pathlib.Path(SERVER_STORAGE_PATH_STR) / PROJECT_PATH_STR
+    MIPMAP_PATH = pathlib.Path(SERVER_STORAGE_PATH_STR) / MIPMAP_PATH_STR
+
+# use the automated stitching results from acquisition software
+IMPORT_TFORMS = False
 
 # for FAST-EM datasets only
-USE_POSITIONS = True  # use the automated stitching results from acquisition software
-MULTIPLE_SECTIONS = True # Set to False for a single section
+MULTIPLE_SECTIONS = True  # Set to False for a single section
+CORRECTIONS_DIR = "postcorrection"
 
-PROJECT_PATHS = natsorted([p / CORRECTIONS_DIR for p in PROJECT_PATH.iterdir() if (p.is_dir() and not p.name.startswith('_'))]) if MULTIPLE_SECTIONS else None
+if MULTIPLE_SECTIONS:
+    project_paths = []
+    for path in PROJECT_PATH.iterdir():
+        if path.is_dir() and not path.name.startswith("_"):
+            project_paths.append(path / CORRECTIONS_DIR)
+    project_paths = natsorted(project_paths)
+else:
+    project_paths = None
 
-   
+
 def _main():
     auth = load_auth()
     match MIPMAP_TYPE:
         case "CLEM":
-            mipmapper = CLEM_Mipmapper(PROJECT_PATH, PARALLEL, CLOBBER)
+            mipmapper = CLEM_Mipmapper(
+                PROJECT_PATH,
+                PARALLEL,
+                CLOBBER,
+                import_tforms=IMPORT_TFORMS,
+                mipmap_path=MIPMAP_PATH
+            )
         case "FASTEM":
             mipmapper = FASTEM_Mipmapper(
-                PROJECT_PATH, PARALLEL, CLOBBER, use_positions=USE_POSITIONS, project_paths=PROJECT_PATHS
+                PROJECT_PATH,
+                PARALLEL,
+                CLOBBER,
+                import_tforms=IMPORT_TFORMS,
+                project_paths=project_paths,
+                mipmap_path=MIPMAP_PATH
             )
         case _:
             raise RuntimeError(f"wrong mipmap type! '{MIPMAP_TYPE}'")
@@ -60,7 +85,6 @@ def _main():
     if not stacks:
         raise RuntimeError("no stacks to upload")
 
-    breakpoint()
     uploader = Uploader(HOST, OWNER, PROJECT, auth, CLOBBER)
     uploader.upload_to_render(stacks, Z_RESOLUTION)
     logging.info("import completed")

--- a/scripted_render_pipeline/importer/clem_mipmapper.py
+++ b/scripted_render_pipeline/importer/clem_mipmapper.py
@@ -15,6 +15,7 @@ from .render_specs import Axis, Tile
 # constants
 SECTION_DIR_PADDING = 3  # amount of digits in a section directory
 SECTION_DIR_GLOB = "S" + "[0-9]" * SECTION_DIR_PADDING
+XY = "X", "Y"
 # amount of digits in each coordinate on an image file name
 IMAGE_FILENAME_PADDING = 5
 TIFFILE_GLOB = (
@@ -41,7 +42,7 @@ xml.etree.ElementTree.register_namespace("", OME_NAMESPACE_URI)
 
 
 class CLEM_Mipmapper(Mipmapper):
-    """creates mipmaps from images and collects tile specs for the CLEM
+    """creates mipmaps from images and collects tile specs for CLEM
 
     project_path: path to project to make mipmaps for
     parallel: how many threads to use in parallel, optimises io usage
@@ -49,12 +50,17 @@ class CLEM_Mipmapper(Mipmapper):
     mipmap_path: where to save mipmaps, defaults to project_path/_mipmaps
 
     additional optional named arguments:
-    invert_em_contrast: inverts the image for the em channel to re
+    invert_em: invert the em layer, this converts backscatter detector type
+        images to look like transmission results, defaults to True,
+        for OSTEM images set this to False
+    use_transforms: use the transforms from the included metadata,
+        defaults to False
     """
 
-    def __init__(self, *args, invert_em_contrast=True, **kwargs):
+    def __init__(self, *args, invert_em=True, use_transforms=False, **kwargs):
         super().__init__(*args, **kwargs)
-        self.invert_em_contrast = invert_em_contrast
+        self.invert_em = invert_em
+        self.use_transforms = use_transforms
 
     def create_mipmaps(self, args):  # override
         file_path, section_name, zvalue, datatype_dir = args
@@ -146,10 +152,12 @@ class CLEM_Mipmapper(Mipmapper):
         # tifffile.OmeXml.validate(description)
         image = page.asarray()
         pixels = element.find("Pixels", NAMESPACE)
+        pixel_count = [int(pixels.attrib["Size" + xy]) for xy in XY]
+
         if channel == "Secondary electrons":
             name = DIR_BY_DATATYPE[datatype_dir]
-            if datatype_dir != "CLEM-grid":
-                image = skimage.util.invert(image)  # invert the SEM image
+            if self.invert_em:
+                image = skimage.util.invert(image)
 
             intensity_clip = 1, 99
         elif (
@@ -196,48 +204,54 @@ class CLEM_Mipmapper(Mipmapper):
 
         timestr = element.find("AcquisitionDate", NAMESPACE).text
         time = datetime.datetime.fromisoformat(timestr)
-        plane = pixels.find("Plane", NAMESPACE)
 
-        tforms = []
-        transform = element.find("Transform", NAMESPACE)
-        if transform is not None:
-            # load transform from spec (often a rotation)
-            model = renderapi.transform.AffineModel()
-            model.M00 = transform.attrib["A00"]
-            model.M01 = transform.attrib["A01"]
-            model.M10 = transform.attrib["A10"]
-            model.M11 = transform.attrib["A11"]
-            model.B0 = transform.attrib["A02"]
-            model.B1 = transform.attrib["A12"]
-            model.load_M()
-            tforms.append(model)
+        # use the transforms from the included metadata
+        if self.use_transforms:
+            plane = pixels.find("Plane", NAMESPACE)
 
-        XY = "X", "Y"
-        # size per pixel in micrometers
-        size = [float(pixels.attrib["PhysicalSize" + xy]) for xy in XY]
-        # scaling on y axis needed to align with an x scaled to 1
-        x_size, y_size = size
-        y_corrected = float(y_size / x_size)
-        if y_corrected:
-            tforms.append(renderapi.transform.AffineModel(M11=y_corrected))
+            tforms = []
+            transform = element.find("Transform", NAMESPACE)
+            if transform is not None:
+                # load transform from spec (often a rotation)
+                model = renderapi.transform.AffineModel()
+                model.M00 = transform.attrib["A00"]
+                model.M01 = transform.attrib["A01"]
+                model.M10 = transform.attrib["A10"]
+                model.M11 = transform.attrib["A11"]
+                model.B0 = transform.attrib["A02"]
+                model.B1 = transform.attrib["A12"]
+                model.load_M()
+                tforms.append(model)
 
-        # invert y
-        # tforms.append(renderapi.transform.AffineModel(M11=-1))
+            # size per pixel in micrometers
+            size = [float(pixels.attrib["PhysicalSize" + xy]) for xy in XY]
+            # scaling on y axis needed to align with an x scaled to 1
+            x_size, y_size = size
+            y_corrected = float(y_size / x_size)
+            if y_corrected:
+                tforms.append(renderapi.transform.AffineModel(M11=y_corrected))
 
-        # pixel count
-        pixels = [int(pixels.attrib["Size" + xy]) for xy in XY]
-        # stage position
-        # NOTE: even though the OME spec specifies this parameter in um it is
-        # erroneously saved in meters
-        position = [plane.attrib["Position" + xy] for xy in XY]
-        # NOTE: the y position needs to be inverted, the input data has origin
-        # in the bottom left corner
-        um_position = [  # convert to micrometers
-            float(pos) * 1e6 * invert for pos, invert in zip(position, (1, -1))
-        ]
+            # invert y
+            # tforms.append(renderapi.transform.AffineModel(M11=-1))
+
+            # stage position
+            # NOTE: even though the OME spec specifies this parameter in um it
+            # is erroneously saved in meters
+            position = [float(plane.attrib["Position" + xy]) for xy in XY]
+            # NOTE: the y position needs to be inverted, the input data has
+            # origin in the bottom left corner
+            um_position = [  # convert to micrometers
+                pos * 1e6 * invert for pos, invert in zip(position, (1, -1))
+            ]
+        else:  # lay out tiles in a grid with no overlap
+            x_size = 1
+            tforms = []
+            um_position = [xy * px for xy, px in zip(x_by_y, pixel_count)]
 
         # calculate boundary box
-        bbox = np.array([[0, 0], [0, pixels[1]], [pixels[0], 0], [*pixels]])
+        bbox = np.array(
+            [[0, 0], [0, pixel_count[1]], [pixel_count[0], 0], [*pixel_count]]
+        )
         for tform in tforms:
             bbox = tform.tform(bbox)
 

--- a/scripted_render_pipeline/importer/fastem_mipmapper.py
+++ b/scripted_render_pipeline/importer/fastem_mipmapper.py
@@ -36,14 +36,12 @@ POSITIONS_LINE_RX = re.compile(
 class FASTEM_Mipmapper(Mipmapper):
     """creates mipmaps from images and collects tile specs for the fastem
 
-    project_path: path to project to make mipmaps for
-    parallel: how many threads to use in parallel, optimises io usage
-    clobber: wether to allow overwriting of existing mipmaps
-    mipmap_path: where to save mipmaps, defaults to project_path/_mipmaps
+    see the Mipmapper class description for arguments
 
     additional optional named arguments:
     project_paths: iterable of multiple project paths, indexed by zlevel
-    use_positions: use the transforms from the positions.txt file
+    use_positions: use the transforms from the positions.txt file,
+        this is identical to import_tforms
     """
 
     def __init__(
@@ -77,7 +75,8 @@ class FASTEM_Mipmapper(Mipmapper):
 
         super().__init__(project_path, *args, **kwargs)
         self.project_paths = project_paths
-        self.use_positions = use_positions
+        if use_positions:
+            self.import_tforms = True
 
     def find_positions(self, project_path):
         """try to find the positions.txt file and parse it
@@ -227,7 +226,7 @@ class FASTEM_Mipmapper(Mipmapper):
         else:
             *_, project_name, section_name = path.parts
 
-        if self.use_positions:
+        if self.import_tforms:
             positions = self.find_positions(path)
         else:
             positions = None

--- a/scripted_render_pipeline/importer/mipmapper.py
+++ b/scripted_render_pipeline/importer/mipmapper.py
@@ -28,6 +28,8 @@ class Mipmapper(abc.ABC):
         previously created mipmaps and give the same results based on the
         source metadata as normal, implies clobber but no mipmaps will be
         overwritten, instead they will be reused
+    import_tforms: try to read and reuse the transforms provided in the
+        metadata, doing this is incompatible with stitching
     """
 
     def __init__(
@@ -37,12 +39,15 @@ class Mipmapper(abc.ABC):
         clobber=False,
         mipmap_path=None,
         reuse_old_mipmaps=False,
+        import_tforms=False,
     ):
         self.remote = False
         self.project_path = project_path
         self.clobber = clobber
         self.parallel = parallel
         self.reuse_old_mipmaps = reuse_old_mipmaps
+        self.import_tforms = import_tforms
+
         if reuse_old_mipmaps:
             self.clobber = True
 


### PR DESCRIPTION
fixes #31 
related #5 but does not work automatically

adds a new parameter to the mipmapper: import_tforms, with this at False the mipmapper will no longer import the transforms from the metadata, this allows it to work with the stitcher in #30 

it also adds the option to invert the em image like in #5 but does not use the metadata to determine this, it needs to be set as a parameter to the clem mipmapper